### PR TITLE
Master callback fix

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test do
   gem "appraisal"
   gem "guard"
   gem "guard-rspec"
+  gem "rspec"
 end

--- a/graphiti-activegraph.gemspec
+++ b/graphiti-activegraph.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activemodel", ">= 4.1"
   spec.add_development_dependency "graphiti_spec_helpers", "1.0.beta.4"
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "rspec", "~> 3.9.0"
 end

--- a/lib/graphiti/active_graph/adapters/active_graph.rb
+++ b/lib/graphiti/active_graph/adapters/active_graph.rb
@@ -15,9 +15,12 @@ module Graphiti::ActiveGraph
       def assign_attributes(model_instance, attributes)
         model_instance.before_assign_resource_attr if model_instance.respond_to?(:before_assign_resource_attr)
 
-        attributes.each_pair do |k, v|
-          model_instance.send(:"#{k}=", v) if model_instance.respond_to?(:"#{k}=")
-        end
+        # currently there is no possible way to assign association on activegraph without triggering save
+        # https://github.com/neo4jrb/activegraph/issues/1445
+        # using "=" operator bypasses validations and callbacks in case of associations
+        # once above issue is fixed, we can change the below code to assign instead of update
+
+        model_instance.update(attributes)
       end
 
       def paginate(scope, current_page, per_page)
@@ -43,7 +46,7 @@ module Graphiti::ActiveGraph
       end
 
       def save(model_instance)
-        model_instance.save
+        model_instance.save if model_instance.changed?
         model_instance
       end
 

--- a/spec/active_graph/adapters/active_graph_spec.rb
+++ b/spec/active_graph/adapters/active_graph_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Graphiti::ActiveGraph::Adapters::ActiveGraph do
+  let(:resource) { double(:resource) }
+  let(:adapter) { described_class.new(resource) }
+  let(:model_instance) { double(:model_instance) }
+  let(:attributes) { { attr_one: 'some_value', attr_two: false, rel: double(:rel) } }
+
+  describe '#assign_attributes' do
+    # https://github.com/neo4jrb/activegraph/issues/1445
+    # saves attributes till above issue is fixed
+    # change the test to check for assignment after fix
+    it 'updates correctly' do
+      expect(model_instance).to receive(:update).with(attributes)
+      adapter.assign_attributes(model_instance, attributes)
+    end
+  end
+
+  describe '#save' do
+    context 'when no change' do
+      it 'does not hit save' do
+        expect(model_instance).to receive(:changed?).and_return(false)
+        expect(model_instance).not_to receive(:save)
+        adapter.save(model_instance)
+      end
+    end
+
+    context 'with change' do
+      it 'saves' do
+        expect(model_instance).to receive(:changed?).and_return(true)
+        expect(model_instance).to receive(:save)
+        adapter.save(model_instance)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,34 @@
+require "pry"
+require "graphiti"
+
+RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
-require "pry"
-require "graphiti"
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+
+require 'pry'
+require 'graphiti'
+require 'graphiti-activegraph'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
**Issue:** In ActiveGraph using `=` operator not only saves directly in db via cypher, but also bypasses validations and other callbacks.

**Solution:** using update method instead which does not bypass validations and callbacks. How ever it still saves in db, untill this issue is solved in ActiveGraph it self there is no workaround.