### PR TITLE
fixes issue where assign_each callback was skipped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+---
+dist: xenial
+language: ruby
+jdk:
+  - openjdk11
+cache: bundler
+rvm:
+  - 2.7.1
+  - jruby-9.2.13.0
+script: 'bundle exec rspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ cache: bundler
 rvm:
   - 2.7.1
   - jruby-9.2.13.0
-script: 'bin/setup default --trace; bundle exec rspec'
+script: 'bundle exec rspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ cache: bundler
 rvm:
   - 2.7.1
   - jruby-9.2.13.0
-script: 'bundle exec rspec'
+script: 'bin/setup default --trace; bundle exec rspec'

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Hardik Joshi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/graphiti/active_graph/sideload_resolve.rb
+++ b/lib/graphiti/active_graph/sideload_resolve.rb
@@ -1,23 +1,6 @@
 module Graphiti::ActiveGraph
   module SideloadResolve
     def resolve_sideloads(parents)
-      @query.sideloads.each_pair do |name, q|
-        sideload = @resource.class.sideload(name)
-        next if sideload.nil? || sideload.shared_remote?
-
-        if sideload.assign_each_proc
-          Array.wrap(parents).each do |parent|
-            children = sideload.assign_each_proc.call(parent) || sideload.default_value_when_empty
-
-            # currently there is no possible way to assign association on activegraph without triggering save
-            # https://github.com/neo4jrb/activegraph/issues/1445
-            # as a workaround we are using instance variable here to store and retrive associations
-            # once above issue is fixed use that fix to assign the association here
-            # and also remove 1) this code and 2) SerializerRelationship#data_proc
-            parent.instance_variable_set("@graphiti_render_#{name}", { data: children })
-          end
-        end
-      end
     end
   end
 end

--- a/lib/graphiti/active_graph/util/serializer_relationship.rb
+++ b/lib/graphiti/active_graph/util/serializer_relationship.rb
@@ -6,11 +6,10 @@ module Graphiti::ActiveGraph
         ->(_) {
           # use custom assigned sideload if it is specified via "assign_each_proc"
           # otherwise retrieve sideload using normal getter on parent object
-          custom_assigned_sideload = @object.instance_variable_get("@graphiti_render_#{sideload_ref.association_name}")
-          records = if custom_assigned_sideload.blank?
-                      @object.public_send(sideload_ref.association_name)
+          records = if custom_proc = sideload_ref.assign_each_proc
+                      custom_proc.call(@object)
                     else
-                      custom_assigned_sideload[:data]
+                      @object.public_send(sideload_ref.association_name)
                     end
 
           if records

--- a/lib/graphiti/active_graph/version.rb
+++ b/lib/graphiti/active_graph/version.rb
@@ -1,5 +1,5 @@
 module Graphiti
   module ActiveGraph
-    VERSION = '0.1.6'
+    VERSION = '0.1.7'
   end
 end

--- a/spec/active_graph/util/serializer_relationship_spec.rb
+++ b/spec/active_graph/util/serializer_relationship_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Graphiti::ActiveGraph::Util::SerializerRelationship do
+  subject { Graphiti::Util::SerializerRelationship.new(resource_class, serializer, sideload) }
+  before do
+    subject.instance_variable_set(:@object, parent_resource)
+    allow(resource_class).to receive(:decorate_record)
+  end
+
+  let(:resource_class) { double(:resource_class) }
+  let(:serializer) { double(:serializer) }
+  let(:sideload) { double(:sideload, association_name: :children, assign_each_proc: assign_each_proc, resource: resource_class) }
+  let(:parent_resource) { double(:parent_resource, children: [resource_one, resource_two]) }
+  let(:resource_one) { double(:resource) }
+  let(:resource_two) { double(:resource) }
+
+  context 'with assign_each_proc' do
+    let(:assign_each_proc) { ->(parent) { parent.children.first } }
+
+    describe '#data_proc' do
+      it 'returns data from assign_each_proc' do
+        expect(subject.data_proc.call(nil)).to eq(resource_one)
+      end
+    end
+  end
+
+  context 'without assign_each_proc is present' do
+    let(:assign_each_proc) { nil }
+
+    describe '#data_proc' do
+      it 'returns data from association call' do
+        expect(subject.data_proc.call(nil)).to eq(parent_resource.children)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require 'pry'
+require 'active_model'
 require 'graphiti'
 require 'graphiti-activegraph'
 


### PR DESCRIPTION
**Issue:**  when chained resource are included (e.g. include='user.friends'), `assign_each` callback on sideload was skipped

**Root Cause:** 
Graphiti calls `data_proc` method on `SerializerRelationship` to get the sideload.

The issue was happening because currently the `assign_each` proc was getting called in `SideloadResolve` module. where we were executing `assign_each` proc and storing it's return value in instance_variable on related resource object. And later when execution comes to `SerializerRelationship#data_proc`, we were using that previously stored instance variable to load the sideload values... Now in case of chained resources, the execution doesn't reach to `SideloadResolve` so no instance variable is set even though the `assign_each` block was given.

**Solution:** Since SerializerRelationship#data_proc is always getting called, I am moving the proc call of `assign_each` to this class.