### PR TITLE
fixes missing include of Filterable

### DIFF
--- a/lib/graphiti/active_graph/scoping/filter.rb
+++ b/lib/graphiti/active_graph/scoping/filter.rb
@@ -1,6 +1,8 @@
 module Graphiti::ActiveGraph
   module Scoping
     module Filter
+      include Filterable
+
       def each_filter
         filter_param.each_pair do |param_name, param_value|
           filter = find_filter!(param_name)

--- a/lib/graphiti/active_graph/version.rb
+++ b/lib/graphiti/active_graph/version.rb
@@ -1,5 +1,5 @@
 module Graphiti
   module ActiveGraph
-    VERSION = '0.1.11'
+    VERSION = '0.1.12'
   end
 end


### PR DESCRIPTION
In Graphiti the `Filterable` module is included in `Filter` module. In `Graphiti::ActiveGraph` both this modules are prepended, but `Filterable` module is not included in `Filter` here. This works correctly when prepended method (`Graphiti::ActiveGraph`'s) takes more priority over Graphiti's methods.

for jruby version 9.3.2.0, the behaviour changes and prepended module doesn't get called, Resulting in bug.

To avoid this bug, including `Filterable` in `Filter` in `Graphiti::ActiveGraph` itself, making sure that the overrided code is always get preference over Graphiti's code.