### PR TITLE
sparse field param supports relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,13 @@ Features:
 
 - Adding unpaginated query to resource proxy with preloaded records. This will help in getting count on API.
 
-<!-- ### [version (DD-MM-YYYY)](diff_link) -->
+## 0.1.15 (21-06-2022)
+
+Features:
+
+- Relationships mentioned in sparse field param (and not in include), will now be returned in relationship block of response
+
+<!-- ### [version (DD-MM-YYYY)] -->
 <!-- Breaking changes:-->
 <!-- Features:-->
 <!-- Fixes:-->

--- a/lib/graphiti-activegraph.rb
+++ b/lib/graphiti-activegraph.rb
@@ -11,6 +11,10 @@ module Graphiti
     end
     module Util
     end
+    module JsonapiExt
+      module Serializable
+      end
+    end
   end
 end
 # End workaround

--- a/lib/graphiti/active_graph/jsonapi_ext/serializable/resource_ext.rb
+++ b/lib/graphiti/active_graph/jsonapi_ext/serializable/resource_ext.rb
@@ -1,14 +1,8 @@
-module Graphiti
-  module ActiveGraph
-    module JsonapiExt
-      module Serializable
-        module ResourceExt
-          def as_jsonapi(fields: nil, include: [])
-            include.merge(fields) if fields.present?
-            super(fields: fields, include: include)
-          end
-        end
-      end
+module Graphiti::ActiveGraph::JsonapiExt::Serializable
+  module ResourceExt
+    def as_jsonapi(fields: nil, include: [])
+      include.merge(fields) if fields.present?
+      super(fields: fields, include: include)
     end
   end
 end

--- a/lib/graphiti/active_graph/version.rb
+++ b/lib/graphiti/active_graph/version.rb
@@ -1,5 +1,5 @@
 module Graphiti
   module ActiveGraph
-    VERSION = '0.1.14'
+    VERSION = '0.1.15'
   end
 end

--- a/spec/active_graph/jsonapi_ext/serializable/resource_ext_spec.rb
+++ b/spec/active_graph/jsonapi_ext/serializable/resource_ext_spec.rb
@@ -1,0 +1,55 @@
+require File.expand_path("../../../support/jsonapi_resource_support", __FILE__)
+
+RSpec.describe JSONAPI::Serializable::Resource do
+  let(:include) { [:planets].to_set }
+  let!(:resource) { SerializableStar.new(object: sun) }
+  subject { resource.as_jsonapi(include: include, fields: fields) }
+
+  let(:sun) { Star.new(id: 1, name: 'Sun', age: 4.6, planets: planets, satellites: satellites) }
+  let(:planets) { [earth, mars] }
+  let(:satellites) { [moon, phobos] }
+
+  let(:earth) { Planet.new(id: 11, name: 'Earth', temperature: 288) }
+  let(:mars) { Planet.new(id: 12, name: 'Mars', temperature: 213) }
+
+  let(:moon) { Satellite.new(id: 111, name: 'Moon', radius: 1737, planet: earth) }
+  let(:phobos) { Satellite.new(id: 121, name: 'Phobos', radius: 11, planet: mars) }
+
+  context 'with fields' do
+    let(:fields) { [:satellites, :age] }
+
+    it 'rel mentioned in fields are present' do
+      expected = {
+        data: [{ type: :satellites, id: '111' },
+               { type: :satellites, id: '121' }]
+      }
+      expect(subject[:relationships][:satellites]).to eq(expected)
+    end
+
+    it 'rel not mentioned in fields are absent' do
+
+      expect(subject[:relationships][:planets]).to be nil
+    end
+
+    it 'only attributes mentioned in fields are present' do
+      expect(subject[:attributes]).to contain_exactly(*sun.attributes_map.slice(:age))
+    end
+  end
+
+  context 'without fields' do
+    let(:fields) { nil }
+
+    it 'rel mentioned in include are present' do
+      expected = {
+        data: [{ type: :planets, id: '11' },
+               { type: :planets, id: '12' }]
+      }
+
+      expect(subject[:relationships][:planets]).to eq(expected)
+    end
+
+    it 'all attributes are present' do
+      expect(subject[:attributes]).to eq(sun.attributes_map)
+    end
+  end
+end

--- a/spec/active_graph/support/jsonapi_resource_support.rb
+++ b/spec/active_graph/support/jsonapi_resource_support.rb
@@ -1,0 +1,74 @@
+class Model
+  def initialize(params = {})
+    @__graphiti_serializer =
+      defined?(graphiti_serializer) ? graphiti_serializer : "Serializable#{self.class.name}".constantize
+
+    params.each do |k, v|
+      instance_variable_set("@#{k}", v)
+    end
+  end
+
+  def attributes_map(skip_id: true)
+    map = self.class.attributes_list.each_with_object({}) do |attr_name, hash|
+      hash[attr_name] = send(attr_name)
+    end
+
+    skip_id ? map.except(:id) : map
+  end
+
+  def self.attributes_list
+    @attributes_list ||= []
+  end
+
+  def self.attributes(*attr_names)
+    attributes_list.concat(attr_names)
+
+    attr_accessor *attr_names
+  end
+
+  def self.relationships(*attr_names)
+    attr_accessor *attr_names
+  end
+end
+
+class Star < Model
+  # age - billion years
+  attributes :id, :name, :age
+  relationships :planets, :satellites
+end
+
+class Planet < Model
+  # temperature - Kelvin
+  attributes :id, :name, :temperature
+  relationships :star, :satellites
+end
+
+class Satellite < Model
+  # radius - Km
+  attributes :id, :name, :radius
+  relationships :star, :planet
+end
+
+class SerializableStar < JSONAPI::Serializable::Resource
+  type 'stars'
+
+  attributes :name, :age
+  relationship :planets, class: 'SerializablePlanet'
+  relationship :satellites, class: 'SerializableSatellite'
+end
+
+class SerializablePlanet < JSONAPI::Serializable::Resource
+  type 'planets'
+
+  attributes :name, :temperature
+  relationship :star, class: 'SerializableStar'
+  relationship :satellites, class: 'SerializableSatellite'
+end
+
+class SerializableSatellite < JSONAPI::Serializable::Resource
+  type 'satellites'
+
+  attributes :name, :radius
+  relationship :star, class: 'SerializableStar'
+  relationship :planet, class: 'SerializablePlanet'
+end


### PR DESCRIPTION
relationships mentioned in sparse field param, will now be returned in relationship block of response. even if they are not given in include params