### PR TITLE
Serializer and Graphiti compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-05-20
+
 ### Added
 
 - **Graphiti Compatibility**: Added support for Graphiti versions up to 1.8.x, fixing previously broken sideloading behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Graphiti Compatibility**: Added support for Graphiti versions up to 1.8.x, fixing previously broken sideloading behavior.
+
+### Fixed
+
+- **Serializer**: Resolved an issue where polymorphic resources were not functioning correctly in serializers.
+
 ## [1.1.0] - 2025-05-2
 
 ### Added

--- a/graphiti-activegraph.gemspec
+++ b/graphiti-activegraph.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'graphiti', '>= 1.6.4'
+  spec.add_dependency 'graphiti', '>= 1.6.4', '<= 1.8.1'
   spec.add_dependency 'activegraph', '>= 12.0.0.beta.5'
   spec.add_dependency 'parslet', '>= 2.0.0'
   spec.add_dependency 'activegraph-extensions', '>= 0.1.0'

--- a/lib/graphiti-activegraph.rb
+++ b/lib/graphiti-activegraph.rb
@@ -24,6 +24,7 @@ Graphiti::Resource::Persistence.prepend Graphiti::ActiveGraph::Resources::Persis
 Graphiti::Resource::Interface::ClassMethods.prepend Graphiti::ActiveGraph::Resources::Interface::ClassMethods
 require 'graphiti'
 Graphiti::Scoping::Filter.prepend Graphiti::ActiveGraph::Scoping::Filter
+Graphiti::Serializer.prepend Graphiti::ActiveGraph::Serializer
 Graphiti::Util::SerializerRelationship.prepend Graphiti::ActiveGraph::Util::SerializerRelationship
 Graphiti::Util::SerializerAttribute.prepend Graphiti::ActiveGraph::Util::SerializerAttribute
 Graphiti::Util::RelationshipPayload.prepend Graphiti::ActiveGraph::Util::RelationshipPayload

--- a/lib/graphiti/active_graph/resource.rb
+++ b/lib/graphiti/active_graph/resource.rb
@@ -84,6 +84,10 @@ module Graphiti
         {}
       end
 
+      def all_models
+        polymorphic? ? self.class.children.map(&:model) : [model]
+      end
+
       private
 
       def scoping_class

--- a/lib/graphiti/active_graph/scoping/internal/sorting_aliases.rb
+++ b/lib/graphiti/active_graph/scoping/internal/sorting_aliases.rb
@@ -5,7 +5,7 @@ module Graphiti::ActiveGraph
       module SortingAliases
         def with_vars_for_sort
           [] unless add_extra_vars_to_query?
-          (deep_sort_keys + sort_keys) & resource.extra_attributes.keys
+          (deep_sort_keys + sort_keys) & resource.extra_attributes.keys - graphiti_query_vars.map(&:to_sym)
         end
 
         def add_extra_vars_to_query?
@@ -18,6 +18,16 @@ module Graphiti::ActiveGraph
 
         def sort_keys
           query.sorts.collect(&:keys).flatten
+        end
+
+        def query
+          @opts[:query_obj]
+        end
+
+        private
+
+        def graphiti_query_vars
+          Graphiti.context.fetch(:with_vars, [])
         end
       end
     end

--- a/lib/graphiti/active_graph/serializer.rb
+++ b/lib/graphiti/active_graph/serializer.rb
@@ -1,0 +1,15 @@
+module Graphiti::ActiveGraph
+  module Serializer
+    def jsonapi_resource_class
+      if polymorphic?
+        "#{jsonapi_type.to_s.singularize.camelize}Resource".constantize
+      else
+        @resource.class
+      end
+    end
+
+    def resource_class_name
+      @_type.to_s.singularize.camelize
+    end
+  end
+end

--- a/lib/graphiti/active_graph/version.rb
+++ b/lib/graphiti/active_graph/version.rb
@@ -1,5 +1,5 @@
 module Graphiti
   module ActiveGraph
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/active_graph/serializer_spec.rb
+++ b/spec/active_graph/serializer_spec.rb
@@ -1,0 +1,39 @@
+describe Graphiti::ActiveGraph::Serializer do
+  describe 'Graphiti::Serializer' do
+    subject { Graphiti::Serializer }
+
+    it { is_expected.to include(Graphiti::ActiveGraph::Serializer) }
+  end
+
+  describe '#jsonapi_resource_class' do
+    let(:serializer_class) do
+      Class.new do
+        def polymorphic?; end
+        def jsonapi_type; end
+      end
+    end
+    let(:polymorphic) { false }
+    let(:resource_obj) { AuthorResource.new }
+    let(:jsonapi_type) { resource_obj.type }
+    let(:serializer) { serializer_class.new }
+
+    before do
+      serializer.class.include Graphiti::ActiveGraph::Serializer
+      allow(serializer).to receive(:polymorphic?).and_return(polymorphic)
+      allow(serializer).to receive(:jsonapi_type).and_return(jsonapi_type)
+      serializer.instance_variable_set(:@resource, resource_obj)
+    end
+
+    it 'returns resource class' do
+      expect(serializer.jsonapi_resource_class).to eq(AuthorResource)
+    end
+
+    context 'with polymorphic resource' do
+      let(:polymorphic) { true }
+
+      it 'returns correct resource class' do
+        expect(serializer.jsonapi_resource_class).to eq(AuthorResource)
+      end
+    end
+  end
+end

--- a/spec/active_graph/sideload_resolve_spec.rb
+++ b/spec/active_graph/sideload_resolve_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Graphiti::Scope do
-  describe '#bypass_scoping' do
-    let(:object) { {} }
-    let(:resource) { Graphiti::ActiveGraph::Resource.new }
-    let(:query) { {} }
+  let(:object) { {} }
+  let(:resource) { Graphiti::ActiveGraph::Resource.new }
+  let(:query) { {} }
+  let(:opts) { {} }
 
+  describe '#bypass_scoping' do
     it 'does not call around_scoping when :preloaded is present in opts' do
       opts = {preloaded: {foo: 1}}
 
@@ -12,12 +13,45 @@ RSpec.describe Graphiti::Scope do
     end
 
     it 'calls around_scoping when :preloaded is not present in opts' do
-      opts = {}
-
       expect(resource).to receive(:around_scoping)
       sideload_resolver = described_class.new(object, resource, query, opts)
     end
   end
 
-  describe
+  describe '#resolve' do
+    let(:zero_results) { false }
+    let(:params) { {} }
+    let(:sideloads) { [] }
+    let(:extra_fields) { {} }
+    let(:query) { double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads:) }
+    let(:results) { [Author.new] }
+    let(:scope) { described_class.new(object, resource, query, opts) }
+    before { allow(resource).to receive(:around_scoping).and_return(results) }
+
+    it 'returns correct results' do
+      expect(scope.resolve).to eq(results)
+    end
+
+    it 'assigns serializer' do
+      expect(scope).to receive(:assign_serializer).with(results)
+      scope.resolve
+    end
+
+    context 'with after_resolve callback' do
+      let(:callback) { ->(results) {} }
+      let(:opts) { { after_resolve: callback } }
+
+      it 'calls it with results' do
+        expect(callback).to receive(:call).with(results)
+        scope.resolve
+      end
+    end
+
+    context 'zero results' do
+      let(:zero_results) { true }
+      subject { scope.resolve }
+
+      it { is_expected.to eq([]) }
+    end
+  end
 end


### PR DESCRIPTION
in newer version of Graphiti (`1.8.x`), they have changed the way sideloads are being resolved in `resolve_with_callbacks` method. That resulted in breaking graphiti-activegraph in newer version of Graphiti.
Graphiti resolves the sideload in multiple queries where as we do that in a single query. I have made changes in `resolve_with_callbacks` to preserve our behaviour and make it compatible with newer version of Graphiti.