### PR TITLE
Added ability to preload extra_fields associations for sideloads

### DIFF
--- a/lib/graphiti/active_graph/resource.rb
+++ b/lib/graphiti/active_graph/resource.rb
@@ -19,14 +19,6 @@ module Graphiti
       def self.guard_nil_id!(params)
       end
 
-      def self.on_extra_attribute(name, preload: nil, &blk)
-        if config[:extra_attributes][name]
-          config[:extra_attributes][name] = { hook: blk, preload: }
-        else
-          raise Errors::ExtraAttributeNotFound.new(self, name)
-        end
-      end
-
       def self.extra_attribute?(name)
         extra_attributes.has_key?(name)
       end

--- a/lib/graphiti/active_graph/scoping/include.rb
+++ b/lib/graphiti/active_graph/scoping/include.rb
@@ -11,8 +11,9 @@ module Graphiti::ActiveGraph
 
       def apply_standard_scope
         return scope if normalized_includes.empty?
+
         self.scope = resource.handle_includes(scope, normalized_includes, normalized_sorts,
-                                              with_vars: with_vars_for_sort, paginate: paginate?)
+                                              extra_fields_includes:, with_vars: with_vars_for_sort, paginate: paginate?)
       end
 
       private
@@ -21,6 +22,14 @@ module Graphiti::ActiveGraph
 
       def query
         @opts[:query_obj]
+      end
+
+      def extra_fields_includes
+        normalized_extra_fields if @query_hash[:extra_fields]
+      end
+
+      def normalized_extra_fields
+        Internal::ExtraFieldNormalizer.new(@query_hash[:extra_fields]).normalize(resource, normalized_includes)
       end
 
       def paginate?

--- a/lib/graphiti/active_graph/scoping/internal/extra_field_normalizer.rb
+++ b/lib/graphiti/active_graph/scoping/internal/extra_field_normalizer.rb
@@ -11,6 +11,7 @@ module Graphiti::ActiveGraph
         def normalize(resource, normalized_includes)
           return [] if @extra_fields.blank?
 
+          process_extra_fields_for_assoc(resource, [], '')
           collect_extra_field_paths(resource, normalized_includes)
           @extra_includes.uniq
         end
@@ -28,11 +29,8 @@ module Graphiti::ActiveGraph
         end
 
         def fetch_assoc_resource(resource, assoc)
-          resource.class&.sideload_resource_class(normalized_assoc_name(assoc))&.new
-        end
-
-        def normalized_assoc_name(assoc)
-          assoc.to_s.split('*').first.to_sym
+          rel_name = Util::Transformers::RelationParam.new(assoc).rel_name_sym
+          resource.class&.sideload_resource_class(rel_name)&.new
         end
 
         def process_extra_fields_for_assoc(assoc_resource, parent_path, assoc)
@@ -70,7 +68,7 @@ module Graphiti::ActiveGraph
         end
 
         def construct_preload_path(parent_path, assoc, preload)
-          (parent_path + [assoc.to_s, preload.to_s]).join('.')
+          (parent_path + [assoc.to_s, preload.to_s]).compact_blank.join('.')
         end
       end
     end

--- a/lib/graphiti/active_graph/scoping/internal/extra_field_normalizer.rb
+++ b/lib/graphiti/active_graph/scoping/internal/extra_field_normalizer.rb
@@ -48,10 +48,24 @@ module Graphiti::ActiveGraph
         end
 
         def add_preload_paths_for_extra_field(config, parent_path, assoc)
-          return unless config && config[:preload]
+          return unless config && config[:preload].present?
             
-          Array(config[:preload]).each do |preload|
+          flatten_preload_hash(config[:preload]).each do |preload|
             @extra_includes << construct_preload_path(parent_path, assoc, preload)
+          end
+        end
+
+        def flatten_preload_hash(preload, prefix = [])
+          case preload
+          when Hash
+            preload.flat_map { |k, v| flatten_preload_hash(v, prefix + [k.to_s]) }
+          when Array
+            preload.flat_map { |v| flatten_preload_hash(v, prefix) }
+          else
+            value = preload.to_s
+            return [] if value.empty?
+
+            [(prefix + [value]).join('.')]
           end
         end
 

--- a/lib/graphiti/active_graph/scoping/internal/extra_field_normalizer.rb
+++ b/lib/graphiti/active_graph/scoping/internal/extra_field_normalizer.rb
@@ -1,0 +1,64 @@
+module Graphiti::ActiveGraph
+  module Scoping
+    module Internal
+      class ExtraFieldNormalizer
+
+        def initialize(extra_fields)
+          @extra_fields = extra_fields
+          @extra_includes = []
+        end
+
+        def normalize(resource, normalized_includes)
+          return [] if @extra_fields.blank?
+
+          collect_extra_field_paths(resource, normalized_includes)
+          @extra_includes.uniq
+        end
+
+        private
+
+        def collect_extra_field_paths(resource, normalized_includes, parent_path = [])
+          normalized_includes.each do |assoc, nested_assoc|
+            assoc_resource = fetch_assoc_resource(resource, assoc)
+            next unless assoc_resource
+
+            process_extra_fields_for_assoc(assoc_resource, parent_path, assoc)
+            collect_extra_field_paths(assoc_resource, nested_assoc, parent_path + [assoc.to_s]) unless nested_assoc.empty?
+          end
+        end
+
+        def fetch_assoc_resource(resource, assoc)
+          resource.class&.sideload_resource_class(normalized_assoc_name(assoc))&.new
+        end
+
+        def normalized_assoc_name(assoc)
+          assoc.to_s.split('*').first.to_sym
+        end
+
+        def process_extra_fields_for_assoc(assoc_resource, parent_path, assoc)
+          return unless @extra_fields.key?(assoc_resource.type)
+
+          Array(@extra_fields[assoc_resource.type]).each do |extra_field|   
+            add_preload_paths_for_extra_field(extra_field_config(assoc_resource, extra_field), parent_path, assoc)
+          end
+        end
+
+        def extra_field_config(assoc_resource, extra_field)
+          assoc_resource.class&.config&.dig(:extra_attributes, extra_field)
+        end
+
+        def add_preload_paths_for_extra_field(config, parent_path, assoc)
+          return unless config && config[:preload]
+            
+          Array(config[:preload]).each do |preload|
+            @extra_includes << construct_preload_path(parent_path, assoc, preload)
+          end
+        end
+
+        def construct_preload_path(parent_path, assoc, preload)
+          (parent_path + [assoc.to_s, preload.to_s]).join('.')
+        end
+      end
+    end
+  end
+end

--- a/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
+++ b/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
@@ -6,7 +6,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
     subject { described_class.new(extra_attributes).normalize(resource, includes) }
 
     context 'when preload value present' do
-      it { is_expected.to eq(['posts.author.posts']) }
+      it { is_expected.to eq(['posts', 'posts.author.posts']) }
     end
 
     context 'when preload value absent' do
@@ -36,7 +36,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
         AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = 'posts*'
       end
 
-      it { is_expected.to eq(['posts.author.posts*']) }
+      it { is_expected.to eq(['posts*', 'posts.author.posts*']) }
     end
 
     context 'when multiple extra_attributes' do
@@ -45,7 +45,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
       end
       let(:extra_attributes) { { authors: [:recent_three_post_titles], posts: [:full_post_title] } }
 
-      it { is_expected.to eq(['posts.author', 'posts.author.posts']) }
+      it { is_expected.to eq(['posts', 'posts.author', 'posts.author.posts']) }
     end
 
     context 'when no extra_attributes' do
@@ -61,7 +61,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
       let(:includes) { {posts: {comments: {}}}}
       let(:extra_attributes) { { authors: [:recent_three_post_titles], posts: [:full_post_title] } }
 
-      it { is_expected.to eq(['posts.author']) }
+      it { is_expected.to eq(['posts', 'posts.author']) }
     end
 
     context 'when preload value is a hash' do
@@ -69,7 +69,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
         AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = { posts: :author }
       end
 
-      it { is_expected.to eq(['posts.author.posts.author']) }
+      it { is_expected.to eq(['posts.author', 'posts.author.posts.author']) }
     end
 
     context 'when preload value is a nested hash' do
@@ -77,7 +77,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
         AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = { posts: { comment: :author } }
       end
 
-      it { is_expected.to eq(['posts.author.posts.comment.author']) }
+      it { is_expected.to eq(['posts.comment.author', 'posts.author.posts.comment.author']) }
     end
 
     context 'when preload value is an array' do
@@ -85,7 +85,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
         AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = [:posts, 'comment']
       end
 
-      it { is_expected.to eq(['posts.author.posts', 'posts.author.comment']) }
+      it { is_expected.to eq(['posts', 'comment', 'posts.author.posts', 'posts.author.comment']) }
     end
   end
 end

--- a/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
+++ b/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
@@ -63,5 +63,29 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
 
       it { is_expected.to eq(['posts.author']) }
     end
+
+    context 'when preload value is a hash' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = { posts: :author }
+      end
+
+      it { is_expected.to eq(['posts.author.posts.author']) }
+    end
+
+    context 'when preload value is a nested hash' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = { posts: { comment: :author } }
+      end
+
+      it { is_expected.to eq(['posts.author.posts.comment.author']) }
+    end
+
+    context 'when preload value is an array' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = [:posts, 'comment']
+      end
+
+      it { is_expected.to eq(['posts.author.posts', 'posts.author.comment']) }
+    end
   end
 end

--- a/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
+++ b/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
@@ -1,0 +1,67 @@
+describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
+  describe '#normalize' do
+    let(:resource) { AuthorResource.new }
+    let(:extra_attributes) { { authors: [:recent_three_post_titles] } }
+    let(:includes) { {posts: {author: {}}}}
+    subject { described_class.new(extra_attributes).normalize(resource, includes) }
+
+    context 'when preload value present' do
+      it { is_expected.to eq(['posts.author.posts']) }
+    end
+
+    context 'when preload value absent' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles] = { hook: -> {} }
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when on_extra_attribute hook absent' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles] = {}
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when extra_attribute does not exist' do
+      let(:extra_attributes) { { authors: [:recent_three_posts] } }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when preload value contains *' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = 'posts*'
+      end
+
+      it { is_expected.to eq(['posts.author.posts*']) }
+    end
+
+    context 'when multiple extra_attributes' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = 'posts'
+      end
+      let(:extra_attributes) { { authors: [:recent_three_post_titles], posts: [:full_post_title] } }
+
+      it { is_expected.to eq(['posts.author', 'posts.author.posts']) }
+    end
+
+    context 'when no extra_attributes' do
+      let(:extra_attributes) {}
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when wrong association passed in includes' do
+      before do
+        AuthorResource.config[:extra_attributes][:recent_three_post_titles][:preload] = 'posts'
+      end
+      let(:includes) { {posts: {comments: {}}}}
+      let(:extra_attributes) { { authors: [:recent_three_post_titles], posts: [:full_post_title] } }
+
+      it { is_expected.to eq(['posts.author']) }
+    end
+  end
+end

--- a/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
+++ b/spec/active_graph/scoping/internal/extra_field_normalizer_spec.rb
@@ -17,7 +17,7 @@ describe Graphiti::ActiveGraph::Scoping::Internal::ExtraFieldNormalizer do
       it { is_expected.to eq([]) }
     end
 
-    context 'when on_extra_attribute hook absent' do
+    context 'when extra_attribute preload parameter absent' do
       before do
         AuthorResource.config[:extra_attributes][:recent_three_post_titles] = {}
       end

--- a/spec/support/factory_bot_setup.rb
+++ b/spec/support/factory_bot_setup.rb
@@ -22,15 +22,28 @@ class PostResource < Graphiti::ActiveGraph::Resource
   attribute :id, :uuid
   attribute :title, :string
   attribute :body, :string
+  extra_attribute :full_post_title, :string do
+    "#{author.name} - #{title}"
+  end
 
   has_one :author, link: false
+  on_extra_attribute :full_post_title, preload: :author do
+    scope.with_association(:author)
+  end
 end
 
 class AuthorResource < Graphiti::ActiveGraph::Resource
   attribute :id, :uuid
   attribute :name, :string
+  extra_attribute :recent_three_post_titles, :array do
+    posts.last(3).map(&:title)
+  end
 
   has_many :posts, link: false
+
+  on_extra_attribute :recent_three_post_titles, preload: :posts do
+    scope.with_association(:posts)
+  end
 end
 
 FactoryBot.define do

--- a/spec/support/factory_bot_setup.rb
+++ b/spec/support/factory_bot_setup.rb
@@ -22,28 +22,21 @@ class PostResource < Graphiti::ActiveGraph::Resource
   attribute :id, :uuid
   attribute :title, :string
   attribute :body, :string
-  extra_attribute :full_post_title, :string do
+  extra_attribute :full_post_title, :string, preload: :author do
     "#{author.name} - #{title}"
   end
 
   has_one :author, link: false
-  on_extra_attribute :full_post_title, preload: :author do
-    scope.with_association(:author)
-  end
 end
 
 class AuthorResource < Graphiti::ActiveGraph::Resource
   attribute :id, :uuid
   attribute :name, :string
-  extra_attribute :recent_three_post_titles, :array do
+  extra_attribute :recent_three_post_titles, :array, preload: :posts do
     posts.last(3).map(&:title)
   end
 
   has_many :posts, link: false
-
-  on_extra_attribute :recent_three_post_titles, preload: :posts do
-    scope.with_association(:posts)
-  end
 end
 
 FactoryBot.define do


### PR DESCRIPTION
**Issue**
Previously, when requesting extra_fields on sideloaded associations, the necessary associations for those extra fields were not preloaded. This resulted in N+1 queries: for each record in the sideload, every extra field would trigger additional database requests.

**Solution**
This PR enables preloading for extra_fields on sideloaded data using the :preload option from the resource config. Now, when you define an extra attribute with a preload value, the necessary associations will be automatically preloaded, preventing N+1 queries for computed fields.

**Usage example:**
```
class AuthorResource < ApplicationResource
  extra_attribute :recent_post_titles

  on_extra_attribute :recent_post_titles, preload: :posts do |scope|
    scope.with_associations(:posts)
  end
end
```
When you request the `recent_post_titles` extra field in your API query, the posts association will be preloaded for sideloads as well.

**Possible preload values:**

- String (e.g., 'posts', 'posts*')
- Symbol (e.g., :posts)
- Array (e.g., [:posts, :comments])
- Hash (e.g., {posts: :comments})