### PR TITLE
One plus one preload solution for extra fields

### DIFF
--- a/lib/graphiti/active_graph/sideload_resolve.rb
+++ b/lib/graphiti/active_graph/sideload_resolve.rb
@@ -43,32 +43,77 @@ module Graphiti::ActiveGraph
     end
 
     def preload_extra_fields(results)
-      requested_extra_fields.each do |extra_field_name|
-        next unless preload_extra_field?(extra_field_name)
+      @query.extra_fields.each do |type, extra_field_names|
+        extra_field_names.each do |name|
+          next unless preload_extra_field?(type, name)
 
-        result_map = fetch_preloaded_data(extra_field_name, results)
-        assign_preloaded_data(results, extra_field_name, result_map)
+          records_for_preload = collect_records_for_preload(type, results)
+          result_map = fetch_preloaded_data(type, name, records_for_preload)
+          assign_preloaded_data(records_for_preload, name, result_map)
+        end
       end
     end
 
-    def requested_extra_fields
-      @query.extra_fields[@resource.type] || []
-    end
-
-    def fetch_preloaded_data(extra_field_name, results)
-      @resource.model.public_send(default_preload_method(extra_field_name), results.pluck(:id))
+    def fetch_preloaded_data(type, extra_field_name, results)
+      resource_for_preload(type).model.public_send(default_preload_method(extra_field_name), results.pluck(:id).uniq)
     end
 
     def assign_preloaded_data(results, extra_field_name, result_map)
       results.each { |r| r.public_send("#{extra_field_name}=", result_map[r.id]) }
     end
 
-    def preload_extra_field?(extra_field_name)
-      @resource.extra_attribute?(extra_field_name) && @resource.model.respond_to?(default_preload_method(extra_field_name))
+    def preload_extra_field?(type, extra_field_name)
+      resource = resource_for_preload(type)
+      resource && resource.extra_attribute?(extra_field_name) && resource.model.respond_to?(default_preload_method(extra_field_name))
+    end
+
+    def resource_for_preload(type)
+      return @resource if type == @resource.type
+
+      find_resource_in_included_associations(type)
+    end
+
+    def find_resource_in_included_associations(type, sideload_query = @query)
+      sideload_query.sideloads.values.each do |sideload|
+        return sideload.resource if sideload.resource.type == type
+
+        resource = find_resource_in_included_associations(type, sideload)
+        return resource if resource
+      end
+
+      nil
     end
 
     def default_preload_method(extra_field_name)
       "#{PRELOAD_METHOD_PREFIX}#{extra_field_name}"
+    end
+
+    def collect_records_for_preload(type, results)
+      base_records = resource_matches_type?(@resource, type) ? Array(results) : []
+      sideloaded_records = collect_sideloaded_records(Array(results), @query, type)
+      (base_records + sideloaded_records).flatten.compact.uniq
+    end
+
+    def collect_sideloaded_records(source_records, sideload_query, type)
+      return [] if source_records.empty? || sideload_query.sideloads.empty?
+
+      sideload_query.sideloads.flat_map do |sideload_name, nested_query|
+        associated_records = collect_associated_records(source_records, sideload_name)
+        matched_records = resource_matches_type?(nested_query.resource, type) ? associated_records : []
+        matched_records + collect_sideloaded_records(associated_records, nested_query, type)
+      end
+    end
+
+    def resource_matches_type?(resource, type)
+      resource&.type == type
+    end
+
+    def collect_associated_records(source_records, sideload_name)
+      source_records.flat_map do |parent|
+        next [] unless parent.respond_to?(sideload_name)
+
+        Array(parent.public_send(sideload_name)).compact
+      end
     end
   end
 end

--- a/lib/graphiti/active_graph/sideload_resolve.rb
+++ b/lib/graphiti/active_graph/sideload_resolve.rb
@@ -70,7 +70,7 @@ module Graphiti::ActiveGraph
     def resource_for_preload(type)
       return @resource if type == @resource.type
 
-      find_resource_in_included_associations(type)
+      find_resource_in_included_associations(type) unless @query.sideloads.empty?
     end
 
     def find_resource_in_included_associations(type, sideload_query = @query)

--- a/spec/active_graph/sideload_resolve_spec.rb
+++ b/spec/active_graph/sideload_resolve_spec.rb
@@ -53,5 +53,110 @@ RSpec.describe Graphiti::Scope do
 
       it { is_expected.to eq([]) }
     end
+
+    context 'extra_fields preloading' do
+      let(:params) { { extra_fields: { authors: [:posts_number]} } }
+      let(:extra_fields) { {authors: [:posts_number]} }
+      let(:query) { double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads:) }
+      let(:results) { [author_with_post] }
+      let(:resource) { AuthorResource.new }
+      let(:author_with_post) { create(:author, :with_post) }
+      let(:scope) do
+        allow(resource).to receive(:around_scoping).and_return(results)
+        described_class.new(object, resource, query, opts)
+      end
+
+      it 'assigns extra_field instance variable' do
+        scope.resolve
+        expect(author_with_post.instance_variable_get(:@posts_number)).to eq(1)
+      end
+
+      context 'without preload method' do
+        before { allow(Author).to receive(:respond_to?).with(:preload_posts_number).and_return(false) }
+
+        it 'does not assign extra_field instance variable' do
+          expect(author_with_post.instance_variable_get(:@posts_number)).to eq(nil)
+        end
+      end
+
+      context 'with sideloads' do
+        let(:post_resource) { PostResource.new }
+        let(:post_q) do
+          double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get,
+            sideloads:, resource: post_resource)
+        end
+        let(:query) do
+          double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get,
+            sideloads: { posts: post_q })
+        end
+
+        it 'assigns extra_field instance variable' do
+          scope.resolve
+          expect(author_with_post.instance_variable_get(:@posts_number)).to eq(1)
+        end
+      end
+
+      context 'sideloads contain record for preload' do
+        let(:author_q) { double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads:, resource:) }
+        let(:comment_q) do
+          double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads: { author: author_q }, resource: CommentResource.new)
+        end
+        let(:post_q) do
+          double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads: { comments: comment_q }, resource: PostResource.new)
+        end
+        let(:query) { double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads: { posts: post_q }) }
+        let(:author_with_post) { create(:author, :with_post_and_comment) }
+
+        it 'assigns extra_field instance variable on all found records' do
+          authors = scope.send(:collect_records_for_preload, :authors, results)
+          expect(authors.size).to eq(2)
+          scope.resolve
+          expect(authors.map { |author| author.instance_variable_get(:@posts_number) }).to match_array([1, 2])
+        end
+      end
+
+      context 'multiple extra_fields' do
+        let(:extra_fields) { {authors: [:posts_number], comments: [:author_activity]} }
+        let(:author_q) { double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads:, resource:) }
+        let(:comment_q) do
+          double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads: { author: author_q }, resource: CommentResource.new)
+        end
+        let(:post_q) do
+          double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads: { comments: comment_q }, resource: PostResource.new)
+        end
+        let(:query) { double(:query, zero_results?: zero_results, extra_fields:, params:, action: :get, sideloads: { posts: post_q }) }
+        let(:author_with_post) { create(:author, :with_post_and_comment) }
+
+        it 'assigns extra_field instance variable on all author records' do
+          authors = scope.send(:collect_records_for_preload, :authors, results)
+          expect(authors.size).to eq(2)
+          scope.resolve
+          expect(authors.map { |author| author.instance_variable_get(:@posts_number) }).to match_array([1, 2])
+        end
+
+        it 'assigns extra_field instance variable on all comment records' do
+          comments = scope.send(:collect_records_for_preload, :comments, results)
+          expect(comments.size).to eq(1)
+          scope.resolve
+          expect(comments.first.instance_variable_get(:@author_activity)).to eq(3)
+        end
+      end
+
+      context 'wrong extra_field type' do
+        let(:extra_fields) { {wrong_type: [:posts_number]} }
+        it 'does not assign extra_field instance variable' do
+          scope.resolve
+          expect(author_with_post.instance_variable_get(:@posts_number)).to eq(nil)
+        end
+      end
+
+      context 'wrong extra_field name' do
+        let(:extra_fields) { {authors: [:wrong_name]} }
+        it 'does not assign extra_field instance variable' do
+          scope.resolve
+          expect(author_with_post.instance_variable_get(:@wrong_name)).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/spec/support/factory_bot_setup.rb
+++ b/spec/support/factory_bot_setup.rb
@@ -8,6 +8,30 @@ class Post
   property :body, type: String
 
   has_one :out, :author, type: :author, model_class: :Author
+  has_many :in, :comments, origin: :post
+end
+
+class Comment
+  include ActiveGraph::Node
+  id_property :neo_id
+  property :title, type: String
+  property :body, type: String
+
+  has_one :out, :author, type: :author, model_class: :Author
+  has_one :out, :post, type: :post, model_class: :Post
+
+  attr_writer :author_activity
+
+  def author_activity
+    @author_activity ||= author.comments.count + author.posts.count
+  end
+
+  def self.preload_author_activity(comment_ids)
+    where(id: comment_ids).with_associations(author: [:posts, :comments]).to_h do |comment|
+      author = comment.author
+      [comment.id, author.posts.count + author.comments.count]
+    end
+  end
 end
 
 class Author
@@ -15,7 +39,18 @@ class Author
   id_property :neo_id
   property :name, type: String
 
+  attr_writer :posts_number
+
   has_many :in, :posts, origin: :author
+  has_many :in, :comments, origin: :author
+
+  def posts_number
+    @posts_number ||= posts.count
+  end
+
+  def self.preload_posts_number(author_ids)
+    where(id: author_ids).with_associations(:posts).to_h { |result| [result.id, result.posts.count] }
+  end
 end
 
 class PostResource < Graphiti::ActiveGraph::Resource
@@ -27,6 +62,17 @@ class PostResource < Graphiti::ActiveGraph::Resource
   end
 
   has_one :author, link: false
+  has_many :comments, link: false
+end
+
+class CommentResource < Graphiti::ActiveGraph::Resource
+  attribute :id, :uuid
+  attribute :title, :string
+  attribute :body, :string
+  extra_attribute :author_activity, :integer
+
+  has_one :author, link: false
+  has_one :post, link: false
 end
 
 class AuthorResource < Graphiti::ActiveGraph::Resource
@@ -35,16 +81,26 @@ class AuthorResource < Graphiti::ActiveGraph::Resource
   extra_attribute :recent_three_post_titles, :array, preload: :posts do
     posts.last(3).map(&:title)
   end
+  extra_attribute :posts_number, :integer
 
   has_many :posts, link: false
+  has_many :comments, link: false
 end
 
 FactoryBot.define do
   factory :author do
     name { FFaker::Book.author }
 
-    factory :with_post do
+    trait :with_post do
       posts { [create(:post)] }
+    end
+
+    trait :with_two_posts do
+      posts { [create(:post), create(:post)] }
+    end
+
+    trait :with_post_and_comment do
+      posts { [create(:post, :with_comment_and_author)] }
     end
   end
 
@@ -52,8 +108,29 @@ FactoryBot.define do
     title { FFaker::Book.title }
     body { FFaker::Book.description }
 
-    factory :with_author do
+    trait :with_author do
       author { create(:author) }
+    end
+
+    trait :with_comment do
+      comments { create(:comment, :with_author) }
+    end
+
+    trait :with_comment_and_author do
+      comments { create(:comment, :with_author_and_posts) }
+    end
+  end
+
+  factory :comment do
+    title { FFaker::Book.title }
+    body { FFaker::Book.genre }
+
+    trait :with_author do
+      author { create(:author) }
+    end
+
+    trait :with_author_and_posts do
+      author { create(:author, :with_two_posts) }
     end
   end
 end


### PR DESCRIPTION
This feature enables users to request extra fields for records returned by a query, including both the main results and any records loaded via sideloads. The extra fields are dynamically preloaded and assigned to each record.

**How it works:**
1. User Request:
    - The user specifies [extra_fields] in the query, mapping resource types (e.g., "authors") to extra field names (e.g., [:posts_number]).

3. Preloading Logic:
    - For each requested extra field, the code checks if the associated resource supports it and if a corresponding preload method exists.
    - It collects all records of the target resource type from both the main results and any sideloaded associations.
    - It calls the preload method (e.g., preload_posts_number) on the resource’s model, passing the IDs of all relevant records.
    - The preload method should return a mapping of record IDs to extra field values.

4. Assignment:
    - The code assigns the extra field value to each record using a setter (e.g., record.posts_number = value).

**Example Use Case:**

If a user requests posts_number for authors, the feature will:
  - Find all author records in the results and sideloads,
  - Call Author.preload_posts_number(author_ids),
  - Assign the returned value to each author’s posts_number attribute.
  
**Limitations (Current Implementation):**
This feature does not support preloading for deep sideloads such as posts.comment.author*. Deeply sideloaded authors (e.g., those reached via a chain like posts → comment → author*) will not appear in the array of relevant records for preload, and thus will not have extra fields assigned. Only records directly reachable via the sideload tree are supported for extra field preloading.