### PR TITLE
Improve parsing of group_by criteria

### DIFF
--- a/lib/graphiti/active_graph/extensions/grouping/params.rb
+++ b/lib/graphiti/active_graph/extensions/grouping/params.rb
@@ -1,6 +1,7 @@
 module Graphiti::ActiveGraph::Extensions::Grouping
   class Params
     attr_reader :params, :grouping_criteria_list, :resource_class
+
     def initialize(params, resource_class)
       @params = params
       group_by_string = params.fetch(:group_by, nil)
@@ -37,7 +38,7 @@ module Graphiti::ActiveGraph::Extensions::Grouping
 
     def traverse_to_last_associated_model(model, intermediate_segments)
       intermediate_segments.each do |segment|
-        return false unless(model = associated_model(model, segment))
+        return false unless (model = associated_model(model, segment))
       end
       model
     end
@@ -54,30 +55,46 @@ module Graphiti::ActiveGraph::Extensions::Grouping
       return [] if group_by_string.nil? || group_by_string.empty?
 
       result = []
-      current = ""
+      current = ''
       depth = 0
 
       group_by_string.each_char do |char|
-        case char
-        when '('
-          depth += 1
-          current << char
-        when ')'
-          depth -= 1
-          current << char
-        when ','
-          if depth.zero?
-            result << current.strip unless current.empty?
-            current = ""
-          else
-            current << char
-          end
-        else
-          current << char
-        end
+        depth, current = process_char(char, depth, current, result)
       end
 
-      result << current.strip unless current.empty?
+      add_criterion(result, current)
+      handle_mismatched_parentheses(result, depth)
+    end
+
+    def process_char(char, depth, current, result)
+      case char
+      when '(' then [depth + 1, current + char]
+      when ')' then [depth - 1, current + char]
+      when ',' then process_comma(depth, current, result)
+      else [depth, current + char]
+      end
+    end
+
+    def process_comma(depth, current, result)
+      if depth.zero?
+        add_criterion(result, current)
+        [depth, '']
+      else
+        [depth, current + ',']
+      end
+    end
+
+    def add_criterion(result, current)
+      stripped = current.strip
+      result << stripped unless stripped.empty?
+    end
+
+    def handle_mismatched_parentheses(result, final_depth)
+      return result if final_depth.zero? || result.empty?
+
+      # If we ended with unclosed parentheses, re-split the last segment
+      last_segment = result.pop
+      result.concat(last_segment.split(',').map(&:strip).reject(&:empty?))
       result
     end
   end

--- a/lib/graphiti/active_graph/extensions/grouping/params.rb
+++ b/lib/graphiti/active_graph/extensions/grouping/params.rb
@@ -3,7 +3,8 @@ module Graphiti::ActiveGraph::Extensions::Grouping
     attr_reader :params, :grouping_criteria_list, :resource_class
     def initialize(params, resource_class)
       @params = params
-      @grouping_criteria_list = params.fetch(:group_by, nil)&.split(',') || []
+      group_by_string = params.fetch(:group_by, nil)
+      @grouping_criteria_list = split_grouping_criteria(group_by_string)
       @resource_class = resource_class
     end
 
@@ -47,6 +48,37 @@ module Graphiti::ActiveGraph::Extensions::Grouping
 
     def associated_model(model, segment)
       model.associations[segment.to_sym]&.target_class
+    end
+
+    def split_grouping_criteria(group_by_string)
+      return [] if group_by_string.nil? || group_by_string.empty?
+
+      result = []
+      current = ""
+      depth = 0
+
+      group_by_string.each_char do |char|
+        case char
+        when '('
+          depth += 1
+          current << char
+        when ')'
+          depth -= 1
+          current << char
+        when ','
+          if depth.zero?
+            result << current.strip unless current.empty?
+            current = ""
+          else
+            current << char
+          end
+        else
+          current << char
+        end
+      end
+
+      result << current.strip unless current.empty?
+      result
     end
   end
 end

--- a/lib/graphiti/active_graph/extensions/grouping/params.rb
+++ b/lib/graphiti/active_graph/extensions/grouping/params.rb
@@ -76,7 +76,7 @@ module Graphiti::ActiveGraph::Extensions::Grouping
     end
 
     def process_comma(depth, current, result)
-      if depth.zero?
+      if depth <= 0
         add_criterion(result, current)
         [depth, '']
       else
@@ -90,7 +90,7 @@ module Graphiti::ActiveGraph::Extensions::Grouping
     end
 
     def handle_mismatched_parentheses(result, final_depth)
-      return result if final_depth.zero? || result.empty?
+      return result if final_depth <= 0 || result.empty?
 
       # If we ended with unclosed parentheses, re-split the last segment
       last_segment = result.pop

--- a/spec/active_graph/extensions/grouping/params_spec.rb
+++ b/spec/active_graph/extensions/grouping/params_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Graphiti::ActiveGraph::Extensions::Grouping::Params do
         context 'containing empty parentheses' do
           let(:group_by) { 'impact(),axial_tilt' }
           it { is_expected.to be false }
-          it 'split on commas as usual' do
+          it 'splits on commas as usual' do
             expect(obj.grouping_criteria_list).to eq(['impact()', 'axial_tilt'])
           end
         end
@@ -53,8 +53,16 @@ RSpec.describe Graphiti::ActiveGraph::Extensions::Grouping::Params do
         context 'containing mismatched parentheses with commas' do
           let(:group_by) { 'impact(35,139),((this),string' }
           it { is_expected.to be false }
-          it 'split on commas with unclosed parentheses' do
+          it 'splits on commas with unclosed parentheses' do
             expect(obj.grouping_criteria_list).to eq(['impact(35,139)', '((this)', 'string'])
+          end
+        end
+
+        context 'containing extra closing parenthesis with commas' do
+          let(:group_by) { 'impact(35,139)),axial_tilt' }
+          it { is_expected.to be false }
+          it 'does not split on commas with an extra closing parenthesis' do
+            expect(obj.grouping_criteria_list).to eq(['impact(35,139))', 'axial_tilt'])
           end
         end
       end

--- a/spec/active_graph/extensions/grouping/params_spec.rb
+++ b/spec/active_graph/extensions/grouping/params_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Graphiti::ActiveGraph::Extensions::Grouping::Params do
           let(:group_by) { 'axial_tilt,north_pole_declination' }
           it { is_expected.to be false }
         end
+
+        context 'containing parentheses with commas' do
+          let(:group_by) { 'impact(35,139),axial_tilt' }
+          it { is_expected.to be false }
+          it 'does not split on commas inside parentheses' do
+            expect(obj.grouping_criteria_list).to eq(['impact(35,139)', 'axial_tilt'])
+          end
+        end
       end
 
       context 'when absent' do

--- a/spec/active_graph/extensions/grouping/params_spec.rb
+++ b/spec/active_graph/extensions/grouping/params_spec.rb
@@ -18,11 +18,43 @@ RSpec.describe Graphiti::ActiveGraph::Extensions::Grouping::Params do
           it { is_expected.to be false }
         end
 
+        context 'containing empty parentheses' do
+          let(:group_by) { 'impact(),axial_tilt' }
+          it { is_expected.to be false }
+          it 'split on commas as usual' do
+            expect(obj.grouping_criteria_list).to eq(['impact()', 'axial_tilt'])
+          end
+        end
+
         context 'containing parentheses with commas' do
           let(:group_by) { 'impact(35,139),axial_tilt' }
           it { is_expected.to be false }
           it 'does not split on commas inside parentheses' do
             expect(obj.grouping_criteria_list).to eq(['impact(35,139)', 'axial_tilt'])
+          end
+        end
+
+        context 'containing multiple functions' do
+          let(:group_by) { 'impact(35,139),test(44,44)' }
+          it { is_expected.to be false }
+          it 'does not split on commas inside parentheses' do
+            expect(obj.grouping_criteria_list).to eq(['impact(35,139)', 'test(44,44)'])
+          end
+        end
+
+        context 'containing nested parentheses with commas' do
+          let(:group_by) { 'func1(1,func2(35,139)),axial_tilt' }
+          it { is_expected.to be false }
+          it 'does not split on commas inside nested parentheses' do
+            expect(obj.grouping_criteria_list).to eq(['func1(1,func2(35,139))', 'axial_tilt'])
+          end
+        end
+
+        context 'containing mismatched parentheses with commas' do
+          let(:group_by) { 'impact(35,139),((this),string' }
+          it { is_expected.to be false }
+          it 'split on commas with unclosed parentheses' do
+            expect(obj.grouping_criteria_list).to eq(['impact(35,139)', '((this)', 'string'])
           end
         end
       end


### PR DESCRIPTION
Some criteria for grouping can be functions and come with their own arguments, which means they can contain commas inside parentheses. This PR allows to avoid incorrect splitting of the list of criteria.